### PR TITLE
Fix potential typo in CM2 path?

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To get started, see the _How it works_ section below.
 
 Currently we welcome feedback on: 
  * `/g/data/zv30/non-cmip/ACCESS-CM3/cm3-run-11-08-2025-25km-beta-om3-new-um-params/cm3-demo-datastore/cm3-demo-datastore.json`: CM3 25km ocean which is a present day control with constant forcing (year numbers are essentially meaningless). This run is not made from a released configuration/build so there is no guarantees of it being available or re-producible long-term. Ocean initial conditions are taken from a "cold start" in ACCESS-OM3 (e.g., WOA2023 January).
- * `/g/data/lg87/wgh581/cz681/`: CM2 25km present day control run for comparison. Again year numbers are meaningless but in this case start from "1". We recommend comparing the first N years of this run to ACCESS-CM3 runs to assess the spin-up.
+ * `/g/data/lg87/wgh581/cz861/`: CM2 25km present day control run for comparison. Again year numbers are meaningless but in this case start from "1". We recommend comparing the first N years of this run to ACCESS-CM3 runs to assess the spin-up.
 
 ## How it works
 


### PR DESCRIPTION
@chrisb13 I should probably just merge this but I'm concerned I've done something stupid along the way so would appreciate a second pair of eyes

~~Separately, is there a reason you're directing people to the data and not the datastore for CM2? Seems a touch odd to say "here's a CM3 datastore" and "here's a CM2 directory" even though it looks like there is a CM2 datastore too? Not sure if I've missed something~~ Never mind, I can't find ocean temperature in the datastore so I no longer think recommending it is a good idea